### PR TITLE
Fix use of alt_gui in pfp_gfSOLO.gfSOLO_run_gui().

### DIFF
--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -651,7 +651,7 @@ def gfSOLO_run_gui(solo_gui):
     elif solo_info["peropt"] == 3:
         logger.info("Starting auto (days) run ...")
         # get the start datetime entered in the SOLO GUI
-        nDays = int(alt_gui.lineEdit_NumberDays.text())
+        nDays = int(solo_gui.lineEdit_NumberDays.text())
         if len(str(solo_gui.lineEdit_StartDate.text())) != 0:
             solo_info["startdate"] = str(solo_gui.lineEdit_StartDate.text())
         if len(solo_gui.lineEdit_EndDate.text()) != 0:


### PR DESCRIPTION
Found by Cacilia.
alt_gui used instead of solo_gui at line 654 in pfp_gfSOLO.gfSOLO_run_gui().
Changed alt_gui to solo_gui.