### PR TITLE
Peter/interactive qc l5

### DIFF
--- a/PyFluxPro.py
+++ b/PyFluxPro.py
@@ -570,6 +570,7 @@ class pfp_main_ui(QtGui.QWidget, QPlainTextEditLogger):
         # set the focus back to the log tab
         self.tabs.setCurrentIndex(0)
         # call the appropriate processing routine depending on the level
+        self.tabs.tab_index_running = tab_index_current
         if self.tabs.cfg_dict[tab_index_current]["level"] == "L1":
             pfp_top_level.do_run_l1(cfg=cfg)
         elif self.tabs.cfg_dict[tab_index_current]["level"] == "L2":

--- a/scripts/pfp_ck.py
+++ b/scripts/pfp_ck.py
@@ -94,14 +94,15 @@ def ApplyTurbulenceFilter(cf,ds,ustar_threshold=None):
     indicators = {}
     # get data for the indicator series
     ustar,ustar_flag,ustar_attr = pfp_utils.GetSeriesasMA(ds,"ustar")
-    Fsd,f,a = pfp_utils.GetSeriesasMA(ds,"Fsd")
-    if "solar_altitude" not in ds.series.keys():
-        pfp_ts.get_synthetic_fsd(ds)
-    Fsd_syn,f,a = pfp_utils.GetSeriesasMA(ds,"Fsd_syn")
-    sa,f,a = pfp_utils.GetSeriesasMA(ds,"solar_altitude")
+    #Fsd,f,a = pfp_utils.GetSeriesasMA(ds,"Fsd")
+    #if "solar_altitude" not in ds.series.keys():
+        #pfp_ts.get_synthetic_fsd(ds)
+    #Fsd_syn,f,a = pfp_utils.GetSeriesasMA(ds,"Fsd_syn")
+    #sa,f,a = pfp_utils.GetSeriesasMA(ds,"solar_altitude")
     # get the day/night indicator series
     # indicators["day"] = 1 ==> day time, indicators["day"] = 0 ==> night time
-    indicators["day"] = pfp_rp.get_day_indicator(cf,Fsd,Fsd_syn,sa)
+    #indicators["day"] = pfp_rp.get_day_indicator(cf,Fsd,Fsd_syn,sa)
+    indicators["day"] = pfp_rp.get_day_indicator(cf, ds)
     ind_day = indicators["day"]["values"]
     # get the turbulence indicator series
     if opt["turbulence_filter"].lower()=="ustar":
@@ -139,7 +140,8 @@ def ApplyTurbulenceFilter(cf,ds,ustar_threshold=None):
         indicators["final"]["values"][idx] = numpy.int(1)
         indicators["final"]["attr"].update(indicators["day"]["attr"])
     # get the evening indicator series
-    indicators["evening"] = pfp_rp.get_evening_indicator(cf,Fsd,Fsd_syn,sa,ts)
+    #indicators["evening"] = pfp_rp.get_evening_indicator(cf,Fsd,Fsd_syn,sa,ts)
+    indicators["evening"] = pfp_rp.get_evening_indicator(cf, ds)
     indicators["dayevening"] = {"values":indicators["day"]["values"]+indicators["evening"]["values"]}
     indicators["dayevening"]["attr"] = indicators["day"]["attr"].copy()
     indicators["dayevening"]["attr"].update(indicators["evening"]["attr"])

--- a/scripts/pfp_gfSOLO.py
+++ b/scripts/pfp_gfSOLO.py
@@ -219,12 +219,6 @@ def gfSOLO_main(dsa,dsb,solo_info,output_list=[]):
     for output in output_list:
         # get the target series label
         series = dsb.solo[output]["label_tower"]
-        # clean up the target series if required
-        # PRI 05/12/2018 - disabled QC checks on variable at this stage
-        #variable = pfp_utils.GetVariable(dsb, series)
-        #pfp_ck.UpdateVariableAttributes_QC(cf, variable)
-        #pfp_ck.ApplyQCChecks(variable)
-        #pfp_utils.CreateVariable(dsb, variable)
         # check to see if we are gap filling L5 or L4
         if dsb.globalattributes["nc_level"].lower()=="l4":
             for driver in dsb.solo[output]["drivers"]:

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -3407,14 +3407,8 @@ class edit_cfg_L5(QtGui.QWidget):
         """ Handler for when view items are edited."""
         # update the control file contents
         self.cfg_mod = self.get_data_from_model()
-        #
-        idx = self.view.selectedIndexes()[0]
-        level = self.get_level_selected_item()
-        if level == 3:
-            parent_text = str(idx.parent().parent().data())
-        elif level == 4:
-            parent_text = str(idx.parent().parent().parent().data())
-        self.altered.append(parent_text)
+        # update the list of altered series
+        self.update_altered_list()
         # add an asterisk to the tab text to indicate the tab contents have changed
         self.update_tab_text()
 
@@ -3723,12 +3717,16 @@ class edit_cfg_L5(QtGui.QWidget):
         dict_to_add = {"DependencyCheck":{"Source":""}}
         # add the subsubsection (DependencyCheck)
         self.add_subsubsection(dict_to_add)
+        # update the list of altered series
+        self.update_altered_list()
 
     def add_diurnalcheck(self):
         """ Add a diurnal check to a variable."""
         dict_to_add = {"DiurnalCheck":{"NumSd":"5"}}
         # add the subsubsection (DiurnalCheck)
         self.add_subsubsection(dict_to_add)
+        # update the list of altered series
+        self.update_altered_list()
 
     def add_excludedaterange(self):
         """ Add another date range to the ExcludeDates QC check."""
@@ -3748,6 +3746,8 @@ class edit_cfg_L5(QtGui.QWidget):
         dict_to_add = {"ExcludeDates":{"0":"YYYY-mm-dd HH:MM, YYYY-mm-dd HH:MM"}}
         # add the subsubsection (ExcludeDates)
         self.add_subsubsection(dict_to_add)
+        # update the list of altered series
+        self.update_altered_list()
 
     def add_fileentry(self):
         """ Add a new entry to the [Files] section."""
@@ -3878,6 +3878,8 @@ class edit_cfg_L5(QtGui.QWidget):
         dict_to_add = {"RangeCheck":{"Lower":0, "Upper": 1}}
         # add the subsubsection (RangeCheck)
         self.add_subsubsection(dict_to_add)
+        # update the list of altered series
+        self.update_altered_list()
 
     def add_subsection(self, dict_to_add):
         """ Add a subsection to the model."""
@@ -4151,6 +4153,9 @@ class edit_cfg_L5(QtGui.QWidget):
             parent = selected_item.parent()
             # remove the row
             parent.removeRow(selected_item.row())
+        # update the list of altered series
+        self.update_altered_list()
+        # update the tab text
         self.update_tab_text()
 
     def remove_section(self):
@@ -4164,6 +4169,28 @@ class edit_cfg_L5(QtGui.QWidget):
         # remove the row
         root.removeRow(selected_item.row())
         self.update_tab_text()
+
+    def update_altered_list(self):
+        """ Update the list of entries in the control file that have been altered."""
+        idx = self.view.selectedIndexes()[0]
+        level = self.get_level_selected_item()
+        if level == 1 and str(idx.parent().data()) == "Fluxes":
+            parent_text = str(idx.data())
+            if parent_text not in self.altered:
+                self.altered.append(parent_text)
+        elif level == 2 and str(idx.parent().parent().data()) == "Fluxes":
+            parent_text = str(idx.parent().data())
+            if parent_text not in self.altered:
+                self.altered.append(parent_text)
+        elif level == 3 and str(idx.parent().parent().parent().data()) == "Fluxes":
+            parent_text = str(idx.parent().parent().data())
+            if parent_text not in self.altered:
+                self.altered.append(parent_text)
+        elif level == 4 and str(idx.parent().parent().parent().parent().data()) == "Fluxes":
+            parent_text = str(idx.parent().parent().parent().data())
+            if parent_text not in self.altered:
+                self.altered.append(parent_text)
+        return
 
     def update_tab_text(self):
         """ Add an asterisk to the tab title text to indicate tab contents have changed."""

--- a/scripts/pfp_gui.py
+++ b/scripts/pfp_gui.py
@@ -3256,6 +3256,7 @@ class edit_cfg_L5(QtGui.QWidget):
         self.cfg_mod = copy.deepcopy(main_gui.cfg)
 
         self.cfg_changed = False
+        self.altered = []
         self.tabs = main_gui.tabs
 
         self.edit_l5_gui()
@@ -3334,7 +3335,7 @@ class edit_cfg_L5(QtGui.QWidget):
                                     child1 = QtGui.QStandardItem(val)
                                     parent4.appendRow([child0, child1])
                                 parent3.appendRow(parent4)
-                        elif key3 in ["MergeSeries", "RangeCheck", "ExcludeDates"]:
+                        elif key3 in ["MergeSeries", "RangeCheck", "ExcludeDates", "DiurnalCheck", "DependencyCheck"]:
                             for key4 in self.cfg_mod[key1][key2][key3]:
                                 val = self.cfg_mod[key1][key2][key3][key4]
                                 val = self.parse_cfg_variables_value(key3, val)
@@ -3406,6 +3407,14 @@ class edit_cfg_L5(QtGui.QWidget):
         """ Handler for when view items are edited."""
         # update the control file contents
         self.cfg_mod = self.get_data_from_model()
+        #
+        idx = self.view.selectedIndexes()[0]
+        level = self.get_level_selected_item()
+        if level == 3:
+            parent_text = str(idx.parent().parent().data())
+        elif level == 4:
+            parent_text = str(idx.parent().parent().parent().data())
+        self.altered.append(parent_text)
         # add an asterisk to the tab text to indicate the tab contents have changed
         self.update_tab_text()
 

--- a/scripts/pfp_rp.py
+++ b/scripts/pfp_rp.py
@@ -588,11 +588,6 @@ def GetERFromFc(cf, ds, info):
     """
     ldt = ds.series["DateTime"]["Data"]
     ts = int(ds.globalattributes["time_step"])
-    ## get the data
-    #Fsd,Fsd_flag,Fsd_attr = pfp_utils.GetSeriesasMA(ds,"Fsd")
-    #if "solar_altitude" not in ds.series.keys(): pfp_ts.get_synthetic_fsd(ds)
-    #Fsd_syn,flag,attr = pfp_utils.GetSeriesasMA(ds,"Fsd_syn")
-    #sa,flag,attr = pfp_utils.GetSeriesasMA(ds,"solar_altitude")
     er_type_list = info["er"].keys()
     for er_type in er_type_list:
         label_list = info["er"][er_type].keys()
@@ -611,7 +606,6 @@ def GetERFromFc(cf, ds, info):
             idx_notok = numpy.where((Fc["Flag"] != 0))[0]
             ER["Flag"][idx_notok] = numpy.int32(61)
             # get the indicator series
-            #daynight_indicator = get_daynight_indicator(cf, Fsd, Fsd_syn, sa)
             daynight_indicator = get_daynight_indicator(cf, ds)
             idx = numpy.where(daynight_indicator["values"] == 0)[0]
             ER["Flag"][idx] = numpy.int32(63)
@@ -620,7 +614,6 @@ def GetERFromFc(cf, ds, info):
             for item in daynight_indicator["attr"]:
                 ER["Attr"][item] = daynight_indicator["attr"][item]
             pfp_utils.CreateVariable(ds, ER)
-
     return
 
 def check_for_missing_data(series_list,label_list):
@@ -640,40 +633,6 @@ def get_ustar_thresholds(cf,ldt):
         ustar_dict = get_ustarthreshold_from_cf(cf,ldt)
     cleanup_ustar_dict(ldt,ustar_dict)
     return ustar_dict
-
-#def get_daynight_indicator(cf,Fsd,Fsd_syn,sa):
-    ## get the day/night indicator
-    #nRecs = len(Fsd)
-    #daynight_indicator = {"values":numpy.zeros(len(Fsd),dtype=numpy.int32),"attr":{}}
-    #inds = daynight_indicator["values"]
-    #attr = daynight_indicator["attr"]
-    ## get the filter type
-    #filter_type = pfp_utils.get_keyvaluefromcf(cf,["Options"],"DayNightFilter",default="Fsd")
-    #attr["daynight_filter"] = filter_type
-    #use_fsdsyn = pfp_utils.get_keyvaluefromcf(cf,["Options"],"UseFsdsyn_threshold",default="Yes")
-    #attr["use_fsdsyn"] = use_fsdsyn
-    ## get the indicator series
-    #if filter_type.lower()=="fsd":
-        ## get the Fsd threshold
-        #Fsd_threshold = int(pfp_utils.get_keyvaluefromcf(cf,["Options"],"Fsd_threshold",default=10))
-        #attr["Fsd_threshold"] = str(Fsd_threshold)
-        ## we are using Fsd only to define day/night
-        #if use_fsdsyn.lower()=="yes":
-            #idx = numpy.ma.where((Fsd<=Fsd_threshold)&(Fsd_syn<=Fsd_threshold))[0]
-        #else:
-            #idx = numpy.ma.where(Fsd<=Fsd_threshold)[0]
-        #inds[idx] = numpy.int32(1)
-    #elif filter_type.lower()=="sa":
-        ## get the solar altitude threshold
-        #sa_threshold = int(pfp_utils.get_keyvaluefromcf(cf,["Options"],"sa_threshold",default="-5"))
-        #attr["sa_threshold"] = str(sa_threshold)
-        ## we are using solar altitude to define day/night
-        #idx = numpy.ma.where(sa<sa_threshold)[0]
-        #inds[idx] = numpy.int32(1)
-    #else:
-        #msg = "Unrecognised DayNightFilter option in L6 control file"
-        #raise Exception(msg)
-    #return daynight_indicator
 
 def get_daynight_indicator(cf, ds):
     Fsd, f, a = pfp_utils.GetSeriesasMA(ds, "Fsd")
@@ -715,59 +674,6 @@ def get_daynight_indicator(cf, ds):
         msg = "Unrecognised DayNightFilter option in L6 control file"
         raise Exception(msg)
     return daynight_indicator
-
-#def get_day_indicator(cf,Fsd,Fsd_syn,sa):
-    #"""
-    #Purpose:
-     #Returns a dictionary containing an indicator series and some attributes.
-     #The indicator series is 1 during day time and 0 at night time.  The threshold
-     #between night and day is the Fsd threshold specified in the control file.
-    #Usage:
-     #indicators["day"] = get_day_indicator(cf,Fsd,Fsd_syn,sa)
-     #where;
-      #cf is a control file object
-      #Fsd is a series of incoming shortwave radiation values (ndarray)
-      #Fsd_syn is a series of calculated Fsd (ndarray)
-      #sa is a series of solar altitude values (ndarray)
-    #and;
-      #indicators["day"] is a dictionary containing
-      #indicators["day"]["values"] is the indicator series
-      #indicators["day"]["attr"] are the attributes
-    #Author: PRI
-    #Date: March 2016
-    #"""
-    ## indicator = 1 ==> day, indicator = 0 ==> night
-    #day_indicator = {"values":numpy.ones(len(Fsd),dtype=numpy.int32),
-                     #"attr":{}}
-    #inds = day_indicator["values"]
-    #attr = day_indicator["attr"]
-    ## get the filter type
-    #filter_type = pfp_utils.get_keyvaluefromcf(cf,["Options"],"DayNightFilter",default="Fsd")
-    #attr["daynight_filter_type"] = filter_type
-    #use_fsdsyn = pfp_utils.get_keyvaluefromcf(cf,["Options"],"UseFsdsyn_threshold",default="Yes")
-    #attr["use_fsdsyn"] = use_fsdsyn
-    ## get the indicator series
-    #if filter_type.lower()=="fsd":
-        ## get the Fsd threshold
-        #Fsd_threshold = int(pfp_utils.get_keyvaluefromcf(cf,["Options"],"Fsd_threshold",default=10))
-        #attr["Fsd_threshold"] = str(Fsd_threshold)
-        ## we are using Fsd only to define day/night
-        #if use_fsdsyn.lower()=="yes":
-            #idx = numpy.ma.where((Fsd<=Fsd_threshold)&(Fsd_syn<=Fsd_threshold))[0]
-        #else:
-            #idx = numpy.ma.where(Fsd<=Fsd_threshold)[0]
-        #inds[idx] = numpy.int32(0)
-    #elif filter_type.lower()=="sa":
-        ## get the solar altitude threshold
-        #sa_threshold = int(pfp_utils.get_keyvaluefromcf(cf,["Options"],"sa_threshold",default="-5"))
-        #attr["sa_threshold"] = str(sa_threshold)
-        ## we are using solar altitude to define day/night
-        #index = numpy.ma.where(sa<sa_threshold)[0]
-        #inds[index] = numpy.int32(0)
-    #else:
-        #msg = "Unrecognised DayNightFilter option in L6 control file"
-        #raise Exception(msg)
-    #return day_indicator
 
 def get_day_indicator(cf, ds):
     """
@@ -828,48 +734,6 @@ def get_day_indicator(cf, ds):
         raise Exception(msg)
     return day_indicator
 
-#def get_evening_indicator(cf,Fsd,Fsd_syn,sa,ts):
-    #"""
-    #Purpose:
-     #Returns a dictionary containing an indicator series and some attributes.
-     #The indicator series is 1 during the evening and 0 at all other times.
-     #Evening is defined as the period between sunset and the number of hours
-     #specified in the control file [Options] section as the EveningFilterLength
-     #key.
-    #Usage:
-     #indicators["evening"] = get_evening_indicator(cf,Fsd,Fsd_syn,sa,ts)
-     #where;
-      #cf is a control file object
-      #Fsd is a series of incoming shortwave radiation values (ndarray)
-      #Fsd_syn is a series of calculated Fsd (ndarray)
-      #sa is a series of solar altitude values (ndarray)
-      #ts is the time step (minutes), integer
-    #and;
-      #indicators["evening"] is a dictionary containing
-      #indicators["evening"]["values"] is the indicator series
-      #indicators["evening"]["attr"] are the attributes
-    #Author: PRI
-    #Date: March 2016
-    #"""
-    #evening_indicator = {"values":numpy.zeros(len(Fsd),dtype=numpy.int32),
-                         #"attr":{}}
-    #attr = evening_indicator["attr"]
-    #opt = pfp_utils.get_keyvaluefromcf(cf,["Options"],"EveningFilterLength",default="0")
-    #num_hours = int(opt)
-    #if num_hours<=0 or num_hours>=12:
-        #evening_indicator = numpy.zeros(len(Fsd))
-        #msg = " Evening filter period outside 0 to 12 hours, skipping ..."
-        #logger.warning(msg)
-        #return evening_indicator
-    #night_indicator = get_night_indicator(cf, Fsd, Fsd_syn, sa)
-    #day_indicator = get_day_indicator(cf, Fsd, Fsd_syn, sa)
-    #ntsperhour = int(0.5+float(60)/float(ts))
-    #shift = num_hours*ntsperhour
-    #day_indicator_shifted = numpy.roll(day_indicator["values"], shift)
-    #evening_indicator["values"] = night_indicator["values"]*day_indicator_shifted
-    #attr["evening_filter_length"] = num_hours
-    #return evening_indicator
-
 def get_evening_indicator(cf, ds):
     """
     Purpose:
@@ -904,72 +768,14 @@ def get_evening_indicator(cf, ds):
         msg = " Evening filter period outside 0 to 12 hours, skipping ..."
         logger.warning(msg)
         return evening_indicator
-
-    #night_indicator = get_night_indicator(cf, Fsd, Fsd_syn, sa)
-    #day_indicator = get_day_indicator(cf, Fsd, Fsd_syn, sa)
     night_indicator = get_night_indicator(cf, ds)
     day_indicator = get_day_indicator(cf, ds)
-
     ntsperhour = int(0.5+float(60)/float(ts))
     shift = num_hours*ntsperhour
     day_indicator_shifted = numpy.roll(day_indicator["values"], shift)
     evening_indicator["values"] = night_indicator["values"]*day_indicator_shifted
     attr["evening_filter_length"] = num_hours
     return evening_indicator
-
-#def get_night_indicator(cf,Fsd,Fsd_syn,sa):
-    #"""
-    #Purpose:
-     #Returns a dictionary containing an indicator series and some attributes.
-     #The indicator series is 1 during night time and 0 during the day.  The
-     #threshold for determining night and day is the Fsd threshold
-     #given in the control file [Options] section.
-    #Usage:
-     #indicators["night"] = get_night_indicator(cf,Fsd,Fsd_syn,sa)
-     #where;
-      #cf is a control file object
-      #Fsd is a series of incoming shortwave radiation values (ndarray)
-      #Fsd_syn is a series of calculated Fsd (ndarray)
-      #sa is a series of solar altitude values (ndarray)
-    #and;
-      #indicators["night"] is a dictionary containing
-      #indicators["night"]["values"] is the indicator series
-      #indicators["night"]["attr"] are the attributes
-    #Author: PRI
-    #Date: March 2016
-    #"""
-    ## indicator = 1 ==> night, indicator = 0 ==> day
-    #night_indicator = {"values":numpy.zeros(len(Fsd),dtype=numpy.int32),
-                       #"attr":{}}
-    #inds = night_indicator["values"]
-    #attr = night_indicator["attr"]
-    ## get the filter type
-    #filter_type = pfp_utils.get_keyvaluefromcf(cf,["Options"],"DayNightFilter",default="Fsd")
-    #attr["daynight_filter_type"] = filter_type
-    #use_fsdsyn = pfp_utils.get_keyvaluefromcf(cf,["Options"],"UseFsdsyn_threshold",default="Yes")
-    #attr["use_fsdsyn"] = use_fsdsyn
-    ## get the indicator series
-    #if filter_type.lower()=="fsd":
-        ## get the Fsd threshold
-        #Fsd_threshold = int(pfp_utils.get_keyvaluefromcf(cf,["Options"],"Fsd_threshold",default=10))
-        #attr["Fsd_threshold"] = str(Fsd_threshold)
-        ## we are using Fsd only to define day/night
-        #if use_fsdsyn.lower()=="yes":
-            #idx = numpy.ma.where((Fsd<=Fsd_threshold)&(Fsd_syn<=Fsd_threshold))[0]
-        #else:
-            #idx = numpy.ma.where(Fsd<=Fsd_threshold)[0]
-        #inds[idx] = numpy.int32(1)
-    #elif filter_type.lower()=="sa":
-        ## get the solar altitude threshold
-        #sa_threshold = int(pfp_utils.get_keyvaluefromcf(cf,["Options"],"sa_threshold",default="-5"))
-        #attr["sa_threshold"] = str(sa_threshold)
-        ## we are using solar altitude to define day/night
-        #index = numpy.ma.where(sa<sa_threshold)[0]
-        #inds[index] = numpy.int32(1)
-    #else:
-        #msg = "Unrecognised DayNightFilter option in L6 control file"
-        #raise Exception(msg)
-    #return night_indicator
 
 def get_night_indicator(cf, ds):
     """


### PR DESCRIPTION
Now able to add or edit QC checks to the L5 control file via the GUI while the "SOLO" GUI is displayed.  The changed control file is read every time a manual run is done.  This allows a more interactive QC process when gap filling at L5.
Only implemented for manual runs at this stage.